### PR TITLE
fix: Sort transactions by creation date in user profile

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -47,7 +47,7 @@
 		}
 		currentPage = page;
 		pb.collection('transactions')
-			.getList(page, itemsPerPage, { filter: 'user = "' + $user?.id + '"' ,fields: 'amount,note,created' })
+			.getList(page, itemsPerPage, { filter: 'user = "' + $user?.id + '"' ,fields: 'amount,note,created',sort: '-created' })
 			.then((resp) => {
 				transactions = resp;
 				console.debug('Transactions:', transactions.items);


### PR DESCRIPTION
Transactions in the user profile now sort by creation date, ensuring the correct order is displayed.

Fixes #27