### PR TITLE
Show total count of registered users

### DIFF
--- a/src/routes/manage-users/+page.svelte
+++ b/src/routes/manage-users/+page.svelte
@@ -171,6 +171,13 @@
 
 <div class="container mx-auto">
 	<h1 class="mb-4 text-2xl font-bold">Manage Users</h1>
+	<div class="stats shadow">
+  <div class="stat">
+   
+    <div class="stat-title">Users</div>
+    <div class="stat-value">{$users.length}</div>
+  </div>
+</div>
 	<input
 		type="text"
 		placeholder="Search by name"
@@ -211,6 +218,7 @@
 			aria-label="Unvalidated"
 		/>
 	</div>
+
 	<div class="h-250 overflow-x-auto">
 		<table class="table-pin-cols table-pin-rows table">
 			<!-- head -->


### PR DESCRIPTION
Display the total number of registered users in the user management interface. This change enhances visibility into user registration metrics.

Fixes #49